### PR TITLE
Feature #159265221 – Extend component to run callback on submit

### DIFF
--- a/__test__/GeneSearchForm.test.js
+++ b/__test__/GeneSearchForm.test.js
@@ -103,9 +103,24 @@ describe(`GeneSearchForm`, () => {
     expect(wrapper.find(`button`).at(0).props()).toHaveProperty(`disabled`, true)
   })
 
-  test(`if a function is passed via onSubmit, it is run when the Search button is clicked`, () => {
+  test(`if a function is passed via onSubmit, it is run when the Search button is clicked and the query is passed as args`, () => {
     const onSubmitMock = jest.fn()
     const wrapper = shallow(<GeneSearchForm {...props} onSubmit={onSubmitMock} />)
+
+    const optionValueToSelect = {
+      term: `foo`,
+      category: `bar`
+    }
+    wrapper.find(Autocomplete)
+      .simulate(
+        `change`,
+        {
+          label: `foo`,
+          value: JSON.stringify(optionValueToSelect)
+        })
+
+    const speciesToSelect = species.getRandom()
+    wrapper.find(LabelledSelect).simulate(`change`, {label: speciesToSelect, value: speciesToSelect})
 
     const event = {
       target: `some-DOM-node`
@@ -114,6 +129,8 @@ describe(`GeneSearchForm`, () => {
 
     expect(onSubmitMock.mock.calls).toHaveLength(1)
     expect(onSubmitMock.mock.calls[0][0]).toEqual(event)
+    expect(onSubmitMock.mock.calls[0][1]).toEqual(optionValueToSelect)
+    expect(onSubmitMock.mock.calls[0][2]).toEqual(speciesToSelect)
   })
 
   test(`matches snapshot`, () => {

--- a/__test__/GeneSearchForm.test.js
+++ b/__test__/GeneSearchForm.test.js
@@ -103,6 +103,19 @@ describe(`GeneSearchForm`, () => {
     expect(wrapper.find(`button`).at(0).props()).toHaveProperty(`disabled`, true)
   })
 
+  test(`if a function is passed via onSubmit, it is run when the Search button is clicked`, () => {
+    const onSubmitMock = jest.fn()
+    const wrapper = shallow(<GeneSearchForm {...props} onSubmit={onSubmitMock} />)
+
+    const event = {
+      target: `some-DOM-node`
+    }
+    wrapper.find(`button`).at(0).simulate(`click`, event)
+
+    expect(onSubmitMock.mock.calls).toHaveLength(1)
+    expect(onSubmitMock.mock.calls[0][0]).toEqual(event)
+  })
+
   test(`matches snapshot`, () => {
     const tree = renderer.create(<GeneSearchForm {...props}/>).toJSON()
     expect(tree).toMatchSnapshot()

--- a/__test__/__snapshots__/GeneSearchForm.test.js.snap
+++ b/__test__/__snapshots__/GeneSearchForm.test.js.snap
@@ -167,6 +167,7 @@ exports[`GeneSearchForm matches snapshot 1`] = `
       <button
         className="button"
         disabled={true}
+        onClick={null}
         type="Submit"
       >
         Search

--- a/__test__/__snapshots__/GeneSearchForm.test.js.snap
+++ b/__test__/__snapshots__/GeneSearchForm.test.js.snap
@@ -108,9 +108,9 @@ exports[`GeneSearchForm matches snapshot 1`] = `
     >
       <div>
         <label
-          htmlFor="Species"
+          htmlFor="species"
         >
-          Species
+          species
         </label>
         <div
           className="css-10nd86i"
@@ -131,7 +131,7 @@ exports[`GeneSearchForm matches snapshot 1`] = `
               </div>
               <input
                 className="css-14uuagi"
-                id="Species-input"
+                id="species-input"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}
@@ -150,7 +150,7 @@ exports[`GeneSearchForm matches snapshot 1`] = `
             </div>
           </div>
           <input
-            name="Species"
+            name="species"
             type="hidden"
             value=""
           />

--- a/html/index.html
+++ b/html/index.html
@@ -154,7 +154,7 @@
     atlasUrl: 'http://localhost:8080/gxa/sc/',
     wrapperClassName: 'row expanded',
     actionEndpoint: 'search',
-    onSubmit: function(event) {event.preventDefault() ; console.log(event);},
+    onSubmit: function(event, query, species) {event.preventDefault() ; console.log(event); console.log(query); console.log(species);},
     suggesterEndpoint: 'json/suggestions/gene_ids',
     autocompleteClassName: 'small-8 columns',
     enableSpeciesSelect: true,

--- a/html/index.html
+++ b/html/index.html
@@ -9,6 +9,7 @@
     <style type="text/css">
       #select input,
       #search input,
+      #search-callback input,
       #no_species_select input,
       #no_species_select_human input,
       #no_species_select_mouse input  {
@@ -31,6 +32,21 @@
     <div class="tabs-content" data-tabs-content="search-tabs">
         <div class="tabs-panel is-active " id="search-atlas" style="background-color: #e6e6e6;">
           <div id="search"></div>
+        </div>
+    </div>
+  </div>
+
+<hr>
+
+  <div class="row expanded column">
+    <h2 class="margin-top-xlarge">Full component with callback (open the console for full effect)</h2>
+    <ul class="tabs" data-tabs id="search-tabs">
+      <li class="tabs-title is-active"><a href="#search-atlas" aria-selected="true">Search</a></li>
+    </ul>
+
+    <div class="tabs-content" data-tabs-content="search-tabs">
+        <div class="tabs-panel is-active " id="search-atlas" style="background-color: #e6e6e6;">
+          <div id="search-callback"></div>
         </div>
     </div>
   </div>
@@ -121,7 +137,7 @@
     statusMessage:'An error occurred somewhere along the InterWebz pipes!',
     onChange: function() {}
   }, 'select-error');
-  
+
   geneSearchFormDemo.render({
     atlasUrl: 'http://localhost:8080/gxa/sc/',
     wrapperClassName: 'row expanded',
@@ -133,6 +149,18 @@
     speciesEndpoint: 'json/suggestions/species',
     speciesSelectClassName: 'small-4 columns'
   }, 'search');
+
+  geneSearchFormDemo.render({
+    atlasUrl: 'http://localhost:8080/gxa/sc/',
+    wrapperClassName: 'row expanded',
+    actionEndpoint: 'search',
+    onSubmit: function(event) {event.preventDefault() ; console.log(event);},
+    suggesterEndpoint: 'json/suggestions/gene_ids',
+    autocompleteClassName: 'small-8 columns',
+    enableSpeciesSelect: true,
+    speciesEndpoint: 'json/suggestions/species',
+    speciesSelectClassName: 'small-4 columns'
+  }, 'search-callback');
 
   geneSearchFormDemo.render({
     atlasUrl: 'http://localhost:8080/gxa/sc/',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scxa-gene-search-form",
-  "version": "1.0.2",
+  "version": "1.1.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scxa-gene-search-form",
-  "version": "1.1.0-beta",
+  "version": "1.1.1-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scxa-gene-search-form",
-  "version": "1.1.0-beta",
+  "version": "1.1.1-beta",
   "description": "Single Cell Expression Atlas homepage gene search form",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scxa-gene-search-form",
-  "version": "1.0.2",
+  "version": "1.1.0-beta",
   "description": "Single Cell Expression Atlas homepage gene search form",
   "main": "lib/index.js",
   "scripts": {

--- a/src/FetchLoader.js
+++ b/src/FetchLoader.js
@@ -72,6 +72,7 @@ FetchLoader.propTypes = {
   atlasUrl: PropTypes.string.isRequired,
   wrapperClassName: PropTypes.string,
   actionEndpoint: PropTypes.string.isRequired,
+  onSubmit: PropTypes.func,
 
   autocompleteClassName: PropTypes.string,
   suggesterEndpoint: PropTypes.string.isRequired,

--- a/src/GeneSearchForm.js
+++ b/src/GeneSearchForm.js
@@ -78,7 +78,11 @@ class GeneSearchForm extends React.Component {
               type={`Submit`}
               className={`button`}
               disabled={!this.state.query.term || this.state.query.term.trim() === ``}
-              onClick={onSubmit}>
+              onClick={onSubmit ?
+                (event) => {
+                  onSubmit(event, this.state.query, this.state.selectedSpecies)
+                } :
+                null}>
                 Search
             </button>
           </div>

--- a/src/GeneSearchForm.js
+++ b/src/GeneSearchForm.js
@@ -40,7 +40,7 @@ class GeneSearchForm extends React.Component {
   }
 
   render() {
-    const {wrapperClassName, actionEndpoint} = this.props
+    const {wrapperClassName, actionEndpoint, onSubmit} = this.props
 
     const {autocompleteClassName, atlasUrl, suggesterEndpoint, defaultValue} = this.props
 
@@ -62,7 +62,7 @@ class GeneSearchForm extends React.Component {
           { enableSpeciesSelect &&
             <div className={speciesSelectClassName}>
               <LabelledSelect
-                name={`Species`}
+                name={`species`}
                 topGroup={topSpecies}
                 bottomGroup={allSpecies}
                 bottomGroupLabel={`All species`}
@@ -77,7 +77,8 @@ class GeneSearchForm extends React.Component {
             <button
               type={`Submit`}
               className={`button`}
-              disabled={!this.state.query.term || this.state.query.term.trim() === ``}>
+              disabled={!this.state.query.term || this.state.query.term.trim() === ``}
+              onClick={onSubmit}>
                 Search
             </button>
           </div>
@@ -90,6 +91,7 @@ class GeneSearchForm extends React.Component {
 GeneSearchForm.propTypes = {
   atlasUrl: PropTypes.string.isRequired,
   actionEndpoint: PropTypes.string.isRequired,
+  onSubmit: PropTypes.func,
   wrapperClassName: PropTypes.string,
 
   autocompleteClassName: PropTypes.string,


### PR DESCRIPTION
@lingyun1010 Please have a look at this and compare it to [your previous solution in the branch you created](https://github.com/ebi-gene-expression-group/scxa-gene-search-form/tree/feature/159265221-extend-component-support-SPA).

Notice how this involves a lot less change while it achieves the same: that clicking on the button a callback is run with the query info passed to it. It’s also more flexible since you can let the event bubble up or call `event.preventDefault()`, leaving the user of the component to choose whatever behaviour she wants.